### PR TITLE
Fix build errors on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,13 @@ NO_LAZY_CALL = no
 
 ifeq ($(NCURSES),yes)
   OPTIONS	+= -DNCURSES
-  OPTLIBS	+= -lncursesw
-  OPTLIBS2	+= -lncursesw
+  ifeq ($(shell uname),Darwin)
+    OPTLIBS	+= -lncurses
+    OPTLIBS2	+= -lncurses
+  else
+    OPTLIBS	+= -lncursesw
+    OPTLIBS2	+= -lncursesw
+  endif
 endif
 
 ifeq ($(EVAL_STAT),yes)

--- a/commands.c
+++ b/commands.c
@@ -6,6 +6,10 @@
 #	define _DEFAULT_SOURCE
 #endif /* __FreeBSD__ */
 
+#ifdef __APPLE__
+# define _DARWIN_C_SOURCE    /* define major/minor on macOS */
+#endif
+
 #include <stdio.h>
 #include <wchar.h>
 #include <stdlib.h>
@@ -2097,12 +2101,21 @@ cmd_file(Toy_Interp *interp, Toy_Type *posargs, Hash *nameargs, int arglen) {
 				    new_integer_si(fstat.st_blksize)));
 	l = list_append(l, new_cons(new_symbol(L"blocks"), 
 				    new_integer_si(fstat.st_blocks)));
+#ifdef __APPLE__
+	l = list_append(l, new_cons(new_symbol(L"atime"), 
+				    new_integer_ullsi(fstat.st_atime)));
+	l = list_append(l, new_cons(new_symbol(L"mtime"), 
+				    new_integer_ullsi(fstat.st_mtime)));
+	l = list_append(l, new_cons(new_symbol(L"ctime"), 
+				    new_integer_ullsi(fstat.st_ctime)));
+#else
 	l = list_append(l, new_cons(new_symbol(L"atime"), 
 				    new_integer_ullsi(fstat.st_atim.tv_sec)));
 	l = list_append(l, new_cons(new_symbol(L"mtime"), 
 				    new_integer_ullsi(fstat.st_mtim.tv_sec)));
 	l = list_append(l, new_cons(new_symbol(L"ctime"), 
 				    new_integer_ullsi(fstat.st_ctim.tv_sec)));
+#endif
 
 	if (S_ISSOCK(fstat.st_mode)) {
 	    t = L"s";


### PR DESCRIPTION
macOS上でビルド時に以下のエラーが出たため修正しました。

```
excelsior:perfume$ make
clang -Wall -O2 -c -g  -DNCURSES -I/usr/local/include -I. commands.c -o commands.o
clang -Wall -O2 -c -g  -DNCURSES -I/usr/local/include -I. perfumesh.c -o perfumesh.o
commands.c:2079:24: warning: implicit declaration of function 'major' is invalid
      in C99 [-Wimplicit-function-declaration]
                                    new_integer_si(major(fstat.st_dev))));
                                                   ^
commands.c:2081:24: warning: implicit declaration of function 'minor' is invalid
      in C99 [-Wimplicit-function-declaration]
                                    new_integer_si(minor(fstat.st_dev))));
                                                   ^
commands.c:2101:33: error: no member named 'st_atim' in 'struct stat'
                                    new_integer_ullsi(fstat.st_atim.tv_sec)));
                                                      ~~~~~ ^
commands.c:2103:33: error: no member named 'st_mtim' in 'struct stat'
                                    new_integer_ullsi(fstat.st_mtim.tv_sec)));
                                                      ~~~~~ ^
commands.c:2105:33: error: no member named 'st_ctim' in 'struct stat'
                                    new_integer_ullsi(fstat.st_ctim.tv_sec)));
                                                      ~~~~~ ^
2 warnings and 3 errors generated.
make: *** [commands.o] Error 1
excelsior:perfume$
```